### PR TITLE
Deduplicate extension config from ExtensionRegistrarConfigurator

### DIFF
--- a/compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/services/ExtensionRegistrarConfigurator.kt
+++ b/compiler-plugin/test-fixtures/org/jetbrains/kotlin/compiler/plugin/template/services/ExtensionRegistrarConfigurator.kt
@@ -14,11 +14,11 @@ fun TestConfigurationBuilder.configurePlugin() {
 }
 
 private class ExtensionRegistrarConfigurator(testServices: TestServices) : EnvironmentConfigurator(testServices) {
-  private val registrar = SimplePluginComponentRegistrar()
-  override fun CompilerPluginRegistrar.ExtensionStorage.registerCompilerExtensions(
+    private val registrar = SimplePluginComponentRegistrar()
+    override fun CompilerPluginRegistrar.ExtensionStorage.registerCompilerExtensions(
         module: TestModule,
         configuration: CompilerConfiguration
-  ) {
-    with(registrar) { registerExtensions(configuration) }
-  }
+    ) {
+        with(registrar) { registerExtensions(configuration) }
+    }
 }


### PR DESCRIPTION
This is important for more complex plugins that share state between FIR and IR; also important for plugins that extract info from the compiler configuration.