### PR TITLE
Cleanup `plugin-annotations` targets

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,4 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+kotlin.native.ignoreDisabledTargets=true

--- a/plugin-annotations/build.gradle.kts
+++ b/plugin-annotations/build.gradle.kts
@@ -27,13 +27,11 @@ kotlin {
     linuxX64()
 
     macosArm64()
-    macosX64()
 
     mingwX64()
 
     tvosArm64()
     tvosSimulatorArm64()
-    tvosX64()
 
     wasmJs().nodejs()
     wasmWasi().nodejs()
@@ -42,7 +40,6 @@ kotlin {
     watchosArm64()
     watchosDeviceArm64()
     watchosSimulatorArm64()
-    watchosX64()
 
     applyDefaultHierarchyTemplate()
 }


### PR DESCRIPTION
Also ignores the "disabled native target" warning for better DX